### PR TITLE
Allow setting User-Agent (and other headers), respect port number in urls

### DIFF
--- a/lib/open_graph.rb
+++ b/lib/open_graph.rb
@@ -17,7 +17,7 @@ class OpenGraph
   private
   def parse_opengraph
     begin
-      @response = RedirectFollower.new(@src).resolve
+      @response = RedirectFollower.new(@src, :headers => {'User-Agent' => 'Ruby/opengraph_parser'}).resolve
     rescue
       @title = @url = @src
       return


### PR DESCRIPTION
Also set UA by default to 'Ruby/opengraph_parser'. This feature comes in handy when the targeted url is behind a login screen, some websites allow bots to see the content. And 'Ruby' is slightly too generic for a User Agent string
