### PR TITLE
Initialize can parse html content instead of downloading if it's already available

### DIFF
--- a/spec/lib/open_graph_spec.rb
+++ b/spec/lib/open_graph_spec.rb
@@ -84,5 +84,20 @@ describe OpenGraph do
         end
       end
     end
+
+    context "with body" do
+      it "should parse body instead of downloading it" do
+        content = File.read("#{File.dirname(__FILE__)}/../view/opengraph.html")
+        RedirectFollower.should_not_receive(:new)
+
+        og = OpenGraph.new(content)
+        og.src.should == content
+        og.title.should == "OpenGraph Title"
+        og.type.should == "article"
+        og.url.should == "http://test.host"
+        og.description.should == "My OpenGraph sample site for Rspec"
+        og.images.should == ["http://test.host/images/rock1.jpg", "/images/rock2.jpg"]
+      end
+    end
   end
 end


### PR DESCRIPTION
I needed a way to pass the html to the initialize instead of making OpenGraph download it again.
Since I use it as a step of parsing a HTML it doesn't make sense for me to request it every time.
Tests are ok ;) 
