### PR TITLE
Critical change to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OpengraphParser
 
-OpengraphParser is a simple Ruby library for parsing Open Graph protocol information from a web site. Learn more about the protocol at:
+OpengraphParser is a simple Ruby library for parsing Open Graph protocol information from a website. Learn more about the protocol at:
 http://ogp.me
 
 ## Installation


### PR DESCRIPTION
I literally removed a whitespace to make it `website` instead of `web site`. The [AP Stylebook agrees](https://twitter.com/APStylebook/status/12296505018).

Cheers,
  Lee :beers:

**PS:** Thanks for sharing the gem. It just saved me a couple of hours of work  :metal:
