### PR TITLE
Add extra fallback for description.

### DIFF
--- a/lib/open_graph.rb
+++ b/lib/open_graph.rb
@@ -66,6 +66,10 @@ class OpenGraph
         @description = description_meta.attribute("content").to_s.strip
       end
 
+      if @description.to_s.empty?
+        @description = fetch_first_text(doc)
+      end
+
       fetch_images(doc, "//head//link[@rel='image_src']", "href") if @images.empty?
       fetch_images(doc, "//img", "src") if @images.empty?
     end
@@ -93,6 +97,13 @@ class OpenGraph
   def fetch_images(doc, xpath_str, attr)
     doc.xpath(xpath_str).each do |link|
       add_image(link.attribute(attr).to_s.strip)
+    end
+  end
+
+  def fetch_first_text(doc)
+    doc.xpath('//p').each do |p|
+      s = p.text.to_s.strip
+      return s if s.length > 20
     end
   end
 

--- a/spec/lib/open_graph_spec.rb
+++ b/spec/lib/open_graph_spec.rb
@@ -83,6 +83,21 @@ describe OpenGraph do
           og.images.should == ["http://test.host/images/wall1.jpg", "http://test.host/images/wall2.jpg"]
         end
       end
+
+      context "when website has no opengraph metadata nor description" do
+        it "should lookup for other data from website" do
+          response = double(body: File.open("#{File.dirname(__FILE__)}/../view/opengraph_no_meta_nor_description.html", 'r') { |f| f.read })
+          RedirectFollower.stub(:new) { double(resolve: response) }
+
+          og = OpenGraph.new("http://test.host/child_page")
+          og.src.should == "http://test.host/child_page"
+          og.title.should == "OpenGraph Title Fallback"
+          og.type.should be_nil
+          og.url.should == "http://test.host/child_page"
+          og.description.should == "No description meta here."
+          og.images.should == ["http://test.host/images/wall1.jpg", "http://test.host/images/wall2.jpg"]
+        end
+      end
     end
 
     context "with body" do

--- a/spec/view/opengraph_no_meta_nor_description.html
+++ b/spec/view/opengraph_no_meta_nor_description.html
@@ -1,12 +1,12 @@
 <html>
   <head>
     <title>OpenGraph Title Fallback</title>
-    <meta name="description" content="Short Description Fallback" />
     <meta property="og:type" content="" />
     <meta property="og:url" content="" />
   </head>
   <body>
     <img src="/images/wall1.jpg" />
     <img src="../images/wall2.jpg" />
+    <p>No description meta here.</p>
   </body>
 </html>


### PR DESCRIPTION
Hi,

Some websites do not have any `description` meta, and when using fallback
it is often better to have some kind of result that nothing at all, so I added
a behavior similar to Facebook OpenGraph debugger, where it seems to take
the content of the first long enough paragraph.