### PR TITLE
Fix Image url

### DIFF
--- a/lib/open_graph.rb
+++ b/lib/open_graph.rb
@@ -77,7 +77,7 @@ class OpenGraph
 
   def check_images_path
     @original_images = @images.dup
-    uri = Addressable::URI.parse(@src)
+    uri = Addressable::URI.parse(@url || @src)
     imgs = @images.dup
     @images = []
     imgs.each do |img|

--- a/lib/redirect_follower.rb
+++ b/lib/redirect_follower.rb
@@ -9,7 +9,7 @@ class RedirectFollower
   def initialize(url, limit = REDIRECT_DEFAULT_LIMIT, options = {})
     if limit.is_a? Hash
       options = limit
-      limit = REDIRECT_DEFAULT_LIMIT
+      limit = options[:redirect_limit] || REDIRECT_DEFAULT_LIMIT
     end
     @url, @redirect_limit = url, limit
     @headers = options[:headers] || {}

--- a/spec/lib/open_graph_spec.rb
+++ b/spec/lib/open_graph_spec.rb
@@ -109,6 +109,23 @@ describe OpenGraph do
     end
 
     context "with body" do
+      context "with comment on html" do
+        it "should parse body instead of downloading it" do
+          content = File.read("#{File.dirname(__FILE__)}/../view/opengraph_comment_on_html.html")
+
+          RedirectFollower.should_not_receive(:new)
+
+          og = OpenGraph.new(content)
+          og.src.should == content
+          og.title.should == "OpenGraph Title"
+          og.type.should == "article"
+          og.url.should == "http://test.host"
+          og.description.should == "My OpenGraph sample site for Rspec"
+          og.images.should == ["http://test.host/images/rock1.jpg", "http://test.host/images/rock2.jpg"]
+        end
+
+      end
+
       it "should parse body instead of downloading it" do
         content = File.read("#{File.dirname(__FILE__)}/../view/opengraph.html")
         RedirectFollower.should_not_receive(:new)
@@ -119,7 +136,7 @@ describe OpenGraph do
         og.type.should == "article"
         og.url.should == "http://test.host"
         og.description.should == "My OpenGraph sample site for Rspec"
-        og.images.should == ["http://test.host/images/rock1.jpg", "/images/rock2.jpg"]
+        og.images.should == ["http://test.host/images/rock1.jpg", "http://test.host/images/rock2.jpg"]
       end
     end
   end

--- a/spec/lib/open_graph_spec.rb
+++ b/spec/lib/open_graph_spec.rb
@@ -11,6 +11,14 @@ describe OpenGraph do
       end
     end
 
+    context "with redirect_limit in options hash" do
+      it "should pass redirect_limit to RedirectFollower" do
+        RedirectFollower.should_receive(:new).with("http://test.host", redirect_limit: 20)
+
+        og = OpenGraph.new("http://test.host", redirect_limit: 20)
+      end
+    end
+
     context "with no fallback" do
       it "should get values from opengraph metadata" do
         response = double(body: File.open("#{File.dirname(__FILE__)}/../view/opengraph.html", 'r') { |f| f.read })

--- a/spec/lib/redirect_follower_spec.rb
+++ b/spec/lib/redirect_follower_spec.rb
@@ -11,6 +11,13 @@ describe RedirectFollower do
       m
     }
 
+    context "with redirect_limit in options hash" do
+      it "should update redirect_limit" do
+        rf = RedirectFollower.new(url, redirect_limit: 20)
+        rf.redirect_limit.should == 20
+      end
+    end
+
     context "with no redirection" do
       it "should return the response" do
         uri = URI.parse(URI.escape(url))

--- a/spec/view/opengraph_comment_on_html.html
+++ b/spec/view/opengraph_comment_on_html.html
@@ -1,0 +1,36 @@
+<!--
+===================================================================
+== lovingly brought to you by... ==================================
+===================================================================
+ ______     __  __     ______     ______     __  __     ______
+ /\  ___\   /\ \_\ \   /\  __ \   /\  == \   /\ \/\ \   /\  ___\
+ \ \ \____  \ \  __ \  \ \ \/\ \  \ \  __<   \ \ \_\ \  \ \___  \
+  \ \_____\  \ \_\ \_\  \ \_____\  \ \_\ \_\  \ \_____\  \/\_____\
+    \/_____/   \/_/\/_/   \/_____/   \/_/ /_/   \/_____/   \/_____/
+
+    ===================================================================
+    =============================== http://www.voxmedia.com/careers ===
+    ===================================================================
+-->
+<html>
+  <head>
+    <title>OpenGraph Title Fallback</title>
+    <meta property="og:title" content="OpenGraph Title" />
+    <meta property="og:type" content="article" />
+    <meta property="og:description" content="My OpenGraph sample site for Rspec" />
+    <meta property="og:image" content="http://test.host/images/rock1.jpg" />
+    <meta property="og:image:width" content="300" />
+    <meta property="og:image:height" content="300" />
+    <meta property="og:image" content="/images/rock2.jpg" />
+    <meta property="og:url" content="http://test.host" />
+    <meta property="og:image:height" content="1000" />
+    <meta property="og:locale" content="en_GB" />
+    <meta property="og:locale:alternate" content="fr_FR" />
+    <meta property="og:locale:alternate" content="es_ES" />
+    <meta name="description" content="Short Description Fallback" />
+  </head>
+  <body>
+    <img src="http://test.host/images/wall1.jpg" />
+    <img src="http://test.host/images/wall2.jpg" />
+  </body>
+</html>

--- a/spec/view/opengraph_no_url.html
+++ b/spec/view/opengraph_no_url.html
@@ -1,0 +1,36 @@
+<!--
+===================================================================
+== lovingly brought to you by... ==================================
+===================================================================
+ ______     __  __     ______     ______     __  __     ______
+ /\  ___\   /\ \_\ \   /\  __ \   /\  == \   /\ \/\ \   /\  ___\
+ \ \ \____  \ \  __ \  \ \ \/\ \  \ \  __<   \ \ \_\ \  \ \___  \
+  \ \_____\  \ \_\ \_\  \ \_____\  \ \_\ \_\  \ \_____\  \/\_____\
+    \/_____/   \/_/\/_/   \/_____/   \/_/ /_/   \/_____/   \/_____/
+
+    ===================================================================
+    =============================== http://www.voxmedia.com/careers ===
+    ===================================================================
+-->
+<html>
+  <head>
+    <title>OpenGraph Title Fallback</title>
+    <meta property="og:title" content="OpenGraph Title" />
+    <meta property="og:type" content="article" />
+    <meta property="og:description" content="My OpenGraph sample site for Rspec" />
+    <meta property="og:image" content="http://test.host/images/rock1.jpg" />
+    <meta property="og:image:width" content="300" />
+    <meta property="og:image:height" content="300" />
+    <meta property="og:image" content="/images/rock2.jpg" />
+    <meta property="og:image:height" content="1000" />
+    <meta property="og:locale" content="en_GB" />
+    <meta property="og:url" content="http://test.host" />
+    <meta property="og:locale:alternate" content="fr_FR" />
+    <meta property="og:locale:alternate" content="es_ES" />
+    <meta name="description" content="Short Description Fallback" />
+  </head>
+  <body>
+    <img src="http://test.host/images/wall1.jpg" />
+    <img src="http://test.host/images/wall2.jpg" />
+  </body>
+</html>


### PR DESCRIPTION
When attempting to pass in an HTML source instead of a URL, the parser blows up attempting to load images from a URL of the source. This addresses that issue