### PR TITLE
Fix https URLs

### DIFF
--- a/lib/redirect_follower.rb
+++ b/lib/redirect_follower.rb
@@ -17,7 +17,7 @@ class RedirectFollower
 
     uri = Addressable::URI.parse(url)
 
-    http = Net::HTTP.new(uri.host, uri.port)
+    http = Net::HTTP.new(uri.host, uri.inferred_port)
     if uri.scheme == 'https'
       http.use_ssl = true
       http.verify_mode = OpenSSL::SSL::VERIFY_PEER

--- a/spec/lib/redirect_follower_spec.rb
+++ b/spec/lib/redirect_follower_spec.rb
@@ -15,8 +15,8 @@ describe RedirectFollower do
       it "should return the response" do
         uri = Addressable::URI.parse(url)
 
-        http = Net::HTTP.new(uri.host, uri.port)
-        Net::HTTP.should_receive(:new).with(uri.host, uri.port).and_return(http)
+        http = Net::HTTP.new(uri.host, uri.inferred_port)
+        Net::HTTP.should_receive(:new).with(uri.host, uri.inferred_port).and_return(http)
         http.should_receive(:request_get).and_return(mock_res)
 
         res = RedirectFollower.new(url).resolve
@@ -28,8 +28,8 @@ describe RedirectFollower do
         it "should use https method to retrieve the uri" do
           uri = Addressable::URI.parse(url)
 
-          https = Net::HTTP.new(uri.host, uri.port)
-          Net::HTTP.should_receive(:new).with(uri.host, uri.port).and_return(https)
+          https = Net::HTTP.new(uri.host, uri.inferred_port)
+          Net::HTTP.should_receive(:new).with(uri.host, uri.inferred_port).and_return(https)
           https.should_receive(:request_get).and_return(mock_res)
 
           res = RedirectFollower.new(https_url).resolve
@@ -42,8 +42,8 @@ describe RedirectFollower do
         it "should add headers when retrieve the uri" do
           uri = Addressable::URI.parse(url)
 
-          http = Net::HTTP.new(uri.host, uri.port)
-          Net::HTTP.should_receive(:new).with(uri.host, uri.port).and_return(http)
+          http = Net::HTTP.new(uri.host, uri.inferred_port)
+          Net::HTTP.should_receive(:new).with(uri.host, uri.inferred_port).and_return(http)
           http.should_receive(:request_get).and_return(mock_res)
           res = RedirectFollower.new(url, {:headers => {'User-Agent' => 'My Custom User-Agent'}}).resolve
           res.body.should == "Body is here."
@@ -56,7 +56,7 @@ describe RedirectFollower do
       it "should follow the link in redirection" do
         uri = Addressable::URI.parse(url)
 
-        http = Net::HTTP.new(uri.host, uri.port)
+        http = Net::HTTP.new(uri.host, uri.inferred_port)
         Net::HTTP.should_receive(:new).twice.and_return(http)
         http.should_receive(:request_get).twice.and_return(mock_redirect, mock_res)
 
@@ -70,7 +70,7 @@ describe RedirectFollower do
       it "should raise TooManyRedirects error" do
         uri = Addressable::URI.parse(url)
 
-        http = Net::HTTP.new(uri.host, uri.port)
+        http = Net::HTTP.new(uri.host, uri.inferred_port)
         Net::HTTP.stub(:new).and_return(http)
         http.stub(:request_get).and_return(mock_redirect)
 


### PR DESCRIPTION
`port` returns `nil` unless the port is explicitly supplied (i.e. `https://github.com/` vs `https://github.com:443/`). If `nil` is used then `Net:HTTP` defaults to port 80. So any attempt to use https URLs would result in an error like this:

```
OpenSSL::SSL::SSLError - SSL_connect returned=1 errno=0 state=error: wrong version number:
	/opt/homebrew/Cellar/ruby/3.0.3/lib/ruby/3.0.0/net/protocol.rb:46:in `connect_nonblock'
	/opt/homebrew/Cellar/ruby/3.0.3/lib/ruby/3.0.0/net/protocol.rb:46:in `ssl_socket_connect'
	/opt/homebrew/Cellar/ruby/3.0.3/lib/ruby/3.0.0/net/http.rb:1038:in `connect'
	/opt/homebrew/Cellar/ruby/3.0.3/lib/ruby/3.0.0/net/http.rb:970:in `do_start'
	/opt/homebrew/Cellar/ruby/3.0.3/lib/ruby/3.0.0/net/http.rb:959:in `start'
	/opt/homebrew/Cellar/ruby/3.0.3/lib/ruby/3.0.0/net/http.rb:1512:in `request'
	/opt/homebrew/Cellar/ruby/3.0.3/lib/ruby/3.0.0/net/http.rb:1422:in `request_get'
	/opt/homebrew/lib/ruby/gems/3.0.0/gems/opengraph_parser-0.2.4/lib/redirect_follower.rb:28:in `resolve'
	/opt/homebrew/lib/ruby/gems/3.0.0/gems/opengraph_parser-0.2.4/lib/open_graph.rb:30:in `parse_opengraph'
	/opt/homebrew/lib/ruby/gems/3.0.0/gems/opengraph_parser-0.2.4/lib/open_graph.rb:18:in `initialize'
```

Well, actually, you wouldn't get _any_ error because of that `rescue` clause. 😖 

Anyway, this fixes it. I'm surprised I didn't notice this when I submitted #20. Oh well.