### PR TITLE
Fix text garbling in Japanese

### DIFF
--- a/lib/open_graph.rb
+++ b/lib/open_graph.rb
@@ -27,7 +27,7 @@ class OpenGraph
         @body = @src
         @html_content = true
       else
-        @body = RedirectFollower.new(@src, options).resolve.body
+        @body = RedirectFollower.new(@src, options).resolve.body.force_encoding('utf-8')
         @html_content = false
       end
     rescue


### PR DESCRIPTION
## What

I fix text garbling in Japanese.

Now:

```ruby
irb(main):004> OpenGraph.new("https://www.youtube.com/watch?v=w1JPVRwNhaE").title
=> "ã\u0080\u0090ã\u0081©ã\u0081\u0093è¡\u008Cã\u0081\u008Fï¼\u009Fã\u0080\u00913æ\u0099\u0082é\u0096\u0093ä»¥å\u0086\u0085ã\u0081«æ\u009C\u0080é«\u0098ã\u0081®çµ¶æ\u0099¯ã\u0082\u0092æ\u0092®å½±ã\u0081\u0097ã\u0081¦å¸°ã\u0081£ã\u0081¦ã\u0081\u0093ã\u0081\u0084ï¼\u0081é\u0081¸æ\u0089\u008Bæ¨©"
```

After patched:

```ruby
irb(main):003> OpenGraph.new("https://www.youtube.com/watch?v=w1JPVRwNhaE").title
=> "【どこ行く？】3時間以内に最高の絶景を撮影して帰ってこい！選手権"
```

--

Sorry, I'm  still investigating why this happened.
However, I believe it has something to do with https://github.com/sparklemotion/nokogiri/releases/tag/v1.15.0.
